### PR TITLE
Make sure output directory exists before writing output

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -11,6 +11,8 @@ write <- function(rsmith, files, quiet = FALSE) {
   setwd(dest)
 
   for (file in files) {
+    file_dir <- dirname(file$metadata$.path)
+    if (!file.exists(file_dir)) dir.create(file_dir, recursive = TRUE)
     write_if_different(file$metadata$.path, file$contents)
   }
 


### PR DESCRIPTION
In case the output is in a subdirectory of `dest`.
